### PR TITLE
Compatibility with DataTables 1.13's ES modules

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,19 +1,15 @@
 import $ from 'jquery';
 import 'bootstrap';
-import DataTable from 'datatables.net';
-import Buttons from 'datatables.net-buttons';
-import Select from 'datatables.net-select';
+import DataTable from 'datatables.net-bs5';
+import 'datatables.net-buttons-bs5';
+import 'datatables.net-select-bs5';
 import './dataTables.buttons.js';
 import './dataTables.renderers.js';
 
 window.jQuery = window.$ = $
 window.DataTable = DataTable;
 
-DataTable(window, window.$);
-Buttons(window, window.$);
-Select(window, window.$);
-
-$.extend(true, $.fn.dataTable.defaults, {
+$.extend(true, DataTable.defaults, {
     dom:
         "<'row'<'col-sm-12 mb-4'B>>" +
         "<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>>" +
@@ -21,7 +17,7 @@ $.extend(true, $.fn.dataTable.defaults, {
         "<'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7'p>>",
 });
 
-$.extend(true, $.fn.dataTable.Buttons.defaults, {
+$.extend(true, DataTable.Buttons.defaults, {
     dom: {
         buttonLiner: {
             tag: ''
@@ -29,6 +25,6 @@ $.extend(true, $.fn.dataTable.Buttons.defaults, {
     },
 });
 
-$.extend($.fn.dataTable.ext.classes, {
+$.extend(DataTable.ext.classes, {
     sTable: "dataTable table table-striped table-bordered table-hover",
 });


### PR DESCRIPTION
Now that DataTables provides ES modules, Vite will automatically use them rather than the UMD files. However, the signature of the ESM files is slightly different from the CommonJS loader that was used before. We no longer need to execute a function - it is just present automatically from the import.

I've also shortened the setting of how the default properties are set. It does exactly the same thing.