### PR TITLE
Fix reload button text

### DIFF
--- a/js/buttons/reload.js
+++ b/js/buttons/reload.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         '  <span class="visually-hidden">Loading...</span>\n' +
                         '</i>');
                 } else {
-                    button.html('<i class="bi bi-arrow-repeat"></i>');
+                    button.html(config.text);
                 }
 
                 button.attr('disabled', processing);


### PR DESCRIPTION
We need to reuse the text defined in the config in case the text has been overridden.