### PR TITLE
fix: allow jQuery 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "datatables.net-bs5": "^2.1.8",
     "datatables.net-buttons-bs5": "^3.1.2",
     "datatables.net-select-bs5": "^2.1.0",
-    "jquery": "^3.6.1"
+    "jquery": "^3.6.1 || ^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Widen the package's direct `jquery` dependency from `^3.6.1` to `^3.6.1 || ^4.0.0`.

This resolves #18 by allowing projects that install `jquery@4` at the root to dedupe to the same jQuery instance instead of pulling a nested jQuery 3 copy for `laravel-datatables-vite`.

## Compatibility

The DataTables packages used by this package support this range: the exact declared versions `datatables.net@2.1.8`, `datatables.net-bs5@2.1.8`, `datatables.net-buttons-bs5@3.1.2`, and `datatables.net-select-bs5@2.1.0` all declare `jquery >=1.7`, which includes jQuery 4.

## Validation

- `npm view ... dependencies.jquery` for the DataTables packages listed above
- `npm install --package-lock-only --ignore-scripts --lockfile-version=2`
- `npm pack --dry-run`
- Packed tarball install in a fresh temp project with `jquery@4.0.0`, followed by `npm ls jquery --all` confirming all package dependencies dedupe to `jquery@4.0.0`